### PR TITLE
feat: op-proposer add a `make bindings-upgrades` command 

### DIFF
--- a/op-proposer/Makefile
+++ b/op-proposer/Makefile
@@ -28,7 +28,24 @@ clean:
 test:
 	go test -v ./...
 
+abis = ../packages/contracts-bedrock/snapshots/abi
+
+bindings-upgrades:
+	bash -c ' \
+	set -euxo pipefail; \
+	build_abi() { \
+		local lowercase=$$(echo "$$1" | awk '"'"'{print tolower($$0)}'"'"'); \
+		abigen \
+			--abi "$(abis)/$$1.json" \
+			--pkg bindings \
+			--out "bindings/$$lowercase.go" \
+			--type $$1; \
+	}; \
+	build_abi L2OutputOracle \
+	'
+
 .PHONY: \
 	clean \
 	op-proposer \
-	test
+	test \
+    bindings-upgrades

--- a/op-proposer/Makefile
+++ b/op-proposer/Makefile
@@ -48,4 +48,4 @@ bindings-upgrades:
 	clean \
 	op-proposer \
 	test \
-    bindings-upgrades
+	bindings-upgrades


### PR DESCRIPTION
## Summary

Since `op-bindings` are [deprecated](https://github.com/ethereum-optimism/optimism/pull/10576), add the bindings generation script to make/upgrade go bindings to OP L1 contracts.

## Test Plan

under the `packages/contracts-bedrock`

1. Change the contract codes 
2. Generate the new contract ABI running `npm run snapshots`

under the `op-proposer`

3. Upgrade the bindings file running `make bindings-upgrades `