### PR TITLE
fix finalizer_test.go

### DIFF
--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -252,8 +252,8 @@ func (fi *Finalizer) tryFinalize() {
 			if lastFinalizedBlock != nil {
 				finalizedL2 = *lastFinalizedBlock
 				finalizedDerivedFrom = fd.L1Block
+				fi.log.Debug("set finalized block", "finalized_l2", finalizedL2, "finalized_derived_from", finalizedDerivedFrom, "fd_l2_block", fd.L2Block)
 			}
-			fi.log.Debug("set finalized block", "finalized_derived_from", finalizedDerivedFrom, "fd_l2_block", fd.L2Block)
 
 			// some blocks in the queried range is not BTC finalized, stop iterating to honor consecutive quorom
 			if lastFinalizedBlock == nil || lastFinalizedBlock.Number != fd.L2Block.Number {

--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -243,9 +243,11 @@ func (fi *Finalizer) tryFinalize() {
 	finalizedL2 := fi.lastFinalizedL2 // may be zeroed if nothing was finalized since startup.
 	var finalizedDerivedFrom eth.BlockID
 	// go through the latest inclusion data, and find the last L2 block that was derived from a finalized L1 block
+	fi.log.Debug("tryFinalize", "finalityData", fi.finalityData, "finalizedL2", finalizedL2)
 	for _, fd := range fi.finalityData {
 		if fd.L2Block.Number > finalizedL2.Number && fd.L1Block.Number <= fi.finalizedL1.Number {
 			lastFinalizedBlock := fi.findLastFinalizedL2BlockWithConsecutiveQuorom(fd.L2Block.Number, finalizedL2.Number)
+			fi.log.Debug("finalizing L2 block", "l2_block", fd.L2Block, "derived_from", fd.L1Block, "last_finalized_block", lastFinalizedBlock)
 
 			// set finalized block(s)
 			if lastFinalizedBlock != nil && lastFinalizedBlock.Number == fd.L2Block.Number {

--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -248,14 +248,11 @@ func (fi *Finalizer) tryFinalize() {
 			lastFinalizedBlock := fi.findLastFinalizedL2BlockWithConsecutiveQuorom(fd.L2Block.Number, finalizedL2.Number)
 
 			// set finalized block(s)
-			if lastFinalizedBlock != nil {
-				finalizedL2, finalizedDerivedFrom = fi.updateFinalized(*lastFinalizedBlock, lastFinalizedBlock.L1Origin)
+			if lastFinalizedBlock != nil && lastFinalizedBlock.Number == fd.L2Block.Number {
+				finalizedL2 = *lastFinalizedBlock
+				finalizedDerivedFrom = fd.L1Block
 			}
 
-			// some blocks in the queried range is not BTC finalized, stop iterating to honor consecutive quorom
-			if lastFinalizedBlock == nil || lastFinalizedBlock.Number != fd.L2Block.Number {
-				break
-			}
 			// keep iterating, there may be later L2 blocks that can also be finalized
 		}
 	}
@@ -364,13 +361,6 @@ func (fi *Finalizer) findLastFinalizedL2BlockWithConsecutiveQuorom(
 		}
 	}
 	return nil
-}
-
-func (fi *Finalizer) updateFinalized(lastFinalizedBlock eth.L2BlockRef, fdL1Block eth.BlockID) (eth.L2BlockRef, eth.BlockID) {
-	finalizedL2 := lastFinalizedBlock
-	finalizedDerivedFrom := fdL1Block
-	fi.log.Debug("set finalized block", "l2_block", finalizedL2, "derived_from", finalizedDerivedFrom)
-	return finalizedL2, finalizedDerivedFrom
 }
 
 // onDerivedSafeBlock buffers the L1 block the safe head was fully derived from,

--- a/op-node/rollup/finality/finalizer.go
+++ b/op-node/rollup/finality/finalizer.go
@@ -253,10 +253,10 @@ func (fi *Finalizer) tryFinalize() {
 				finalizedL2 = *lastFinalizedBlock
 				finalizedDerivedFrom = fd.L1Block
 			}
-			fi.log.Debug("set finalized block", "finalized_l2", finalizedL2, "finalized_derived_from", finalizedDerivedFrom, "fd_l2_block", fd.L2Block)
+			fi.log.Debug("set finalized block", "finalized_derived_from", finalizedDerivedFrom, "fd_l2_block", fd.L2Block)
 
 			// some blocks in the queried range is not BTC finalized, stop iterating to honor consecutive quorom
-			if lastFinalizedBlock == nil || finalizedL2.Number != fd.L2Block.Number {
+			if lastFinalizedBlock == nil || lastFinalizedBlock.Number != fd.L2Block.Number {
 				break
 			}
 

--- a/op-node/rollup/finality/finalizer_test.go
+++ b/op-node/rollup/finality/finalizer_test.go
@@ -201,7 +201,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		l2F := &testutils.MockL2Client{}
 		defer l2F.AssertExpectations(t)
-		helperL2BlockRefByNumberWithTimes(t, l2F, 1, refA1, refB0, refB1, refC0, refC1)
+		mockL2BlockRefByNumberWithTimes(l2F, 1, refA1, refB0, refB1, refC0, refC1)
 
 		emitter := &testutils.MockEmitter{}
 		fi := NewFinalizer(context.Background(), logger, &rollup.Config{BabylonConfig: babylonCfg}, l1F, l2F, emitter)
@@ -210,7 +210,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		defer ctl.Finish()
 		sdkClient := mocks.NewMockISdkClient(ctl)
 		fi.babylonFinalityClient = sdkClient
-		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 1, refA1, refB0, refB1, refC0, refC1)
+		mockQueryBlockRangeBabylonFinalizedWithTimes(sdkClient, 1, refA1, refB0, refB1, refC0, refC1)
 
 		// now say C1 was included in D and became the new safe head
 		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1, DerivedFrom: refD})
@@ -245,7 +245,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		l2F := &testutils.MockL2Client{}
 		defer l2F.AssertExpectations(t)
-		helperL2BlockRefByNumberWithTimes(t, l2F, 2, refA1, refB0, refB1, refC0, refC1)
+		mockL2BlockRefByNumberWithTimes(l2F, 2, refA1, refB0, refB1, refC0, refC1)
 
 		emitter := &testutils.MockEmitter{}
 		fi := NewFinalizer(context.Background(), logger, &rollup.Config{BabylonConfig: babylonCfg}, l1F, l2F, emitter)
@@ -253,7 +253,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		defer ctl.Finish()
 		sdkClient := mocks.NewMockISdkClient(ctl)
 		fi.babylonFinalityClient = sdkClient
-		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 2, refA1, refB0, refB1, refC0, refC1)
+		mockQueryBlockRangeBabylonFinalizedWithTimes(sdkClient, 2, refA1, refB0, refB1, refC0, refC1)
 
 		// now say C1 was included in D and became the new safe head
 		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1, DerivedFrom: refD})
@@ -318,8 +318,8 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		emitter.ExpectOnce(engine.PromoteFinalizedEvent{Ref: refC1})
 		l1F.ExpectL1BlockRefByNumber(refD.Number, refD, nil)
 		l1F.ExpectL1BlockRefByNumber(refD.Number, refD, nil)
-		helperL2BlockRefByNumberWithTimes(t, l2F, 2, refA1, refB0, refB1, refC0, refC1)
-		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 2, refA1, refB0, refB1, refC0, refC1)
+		mockL2BlockRefByNumberWithTimes(l2F, 2, refA1, refB0, refB1, refC0, refC1)
+		mockQueryBlockRangeBabylonFinalizedWithTimes(sdkClient, 2, refA1, refB0, refB1, refC0, refC1)
 		fi.OnEvent(TryFinalizeEvent{})
 		emitter.AssertExpectations(t)
 		l1F.AssertExpectations(t)
@@ -333,8 +333,8 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		emitter.ExpectOnce(engine.PromoteFinalizedEvent{Ref: refD0})
 		l1F.ExpectL1BlockRefByNumber(refE.Number, refE, nil)
 		l1F.ExpectL1BlockRefByNumber(refE.Number, refE, nil)
-		helperL2BlockRefByNumberWithTimes(t, l2F, 1, refD0)
-		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 1, refD0)
+		mockL2BlockRefByNumberWithTimes(l2F, 1, refD0)
+		mockQueryBlockRangeBabylonFinalizedWithTimes(sdkClient, 1, refD0)
 		fi.OnEvent(TryFinalizeEvent{})
 		emitter.AssertExpectations(t)
 		l1F.AssertExpectations(t)
@@ -373,8 +373,8 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		emitter.ExpectOnce(engine.PromoteFinalizedEvent{Ref: refF1})
 		l1F.ExpectL1BlockRefByNumber(refH.Number, refH, nil)
 		l1F.ExpectL1BlockRefByNumber(refH.Number, refH, nil)
-		helperL2BlockRefByNumberWithTimes(t, l2F, 1, refD1, refE0, refE1, refF0, refF1)
-		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 1, refD1, refE0, refE1, refF0, refF1)
+		mockL2BlockRefByNumberWithTimes(l2F, 1, refD1, refE0, refE1, refF0, refF1)
+		mockQueryBlockRangeBabylonFinalizedWithTimes(sdkClient, 1, refD1, refE0, refE1, refF0, refF1)
 		fi.OnEvent(TryFinalizeEvent{})
 		emitter.AssertExpectations(t)
 		l1F.AssertExpectations(t)
@@ -391,7 +391,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		l2F := &testutils.MockL2Client{}
 		defer l2F.AssertExpectations(t)
-		helperL2BlockRefByNumberWithTimes(t, l2F, 1, refA1, refB0, refB1)
+		mockL2BlockRefByNumberWithTimes(l2F, 1, refA1, refB0, refB1)
 
 		emitter := &testutils.MockEmitter{}
 		fi := NewFinalizer(context.Background(), logger, &rollup.Config{BabylonConfig: babylonCfg}, l1F, l2F, emitter)
@@ -399,7 +399,7 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		defer ctl.Finish()
 		sdkClient := mocks.NewMockISdkClient(ctl)
 		fi.babylonFinalityClient = sdkClient
-		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 1, refA1, refB0, refB1)
+		mockQueryBlockRangeBabylonFinalizedWithTimes(sdkClient, 1, refA1, refB0, refB1)
 
 		// now say B1 was included in C and became the new safe head
 		fi.OnEvent(engine.SafeDerivedEvent{Safe: refB1, DerivedFrom: refC})
@@ -475,9 +475,9 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC0Alt, DerivedFrom: refDAlt})
 		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1Alt, DerivedFrom: refDAlt})
 
-		helperL2BlockRefByNumberWithTimes(t, l2F, 2, refA1, refB0, refB1, refC0Alt, refC1Alt)
-		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 2, refA1, refB0, refB1)
-		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 2, refC0Alt, refC1Alt)
+		mockL2BlockRefByNumberWithTimes(l2F, 2, refA1, refB0, refB1, refC0Alt, refC1Alt)
+		mockQueryBlockRangeBabylonFinalizedWithTimes(sdkClient, 2, refA1, refB0, refB1)
+		mockQueryBlockRangeBabylonFinalizedWithTimes(sdkClient, 2, refC0Alt, refC1Alt)
 
 		// We get an early finality signal for F, of the chain that did not include refC0Alt and refC1Alt,
 		// as L1 block F does not build on DAlt.
@@ -519,8 +519,8 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		// and don't expect a finality attempt.
 		emitter.AssertExpectations(t)
 
-		helperL2BlockRefByNumberWithTimes(t, l2F, 1, refA1, refB0, refB1, refC0)
-		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 1, refA1, refB0, refB1, refC0)
+		mockL2BlockRefByNumberWithTimes(l2F, 1, refA1, refB0, refB1, refC0)
+		mockQueryBlockRangeBabylonFinalizedWithTimes(sdkClient, 1, refA1, refB0, refB1, refC0)
 
 		// if we reset the attempt, then we can finalize however.
 		fi.triedFinalizeAt = 0
@@ -533,13 +533,13 @@ func TestEngineQueue_Finalize(t *testing.T) {
 	})
 }
 
-func helperL2BlockRefByNumberWithTimes(t *testing.T, l2F *testutils.MockL2Client, times int, refs ...eth.L2BlockRef) {
+func mockL2BlockRefByNumberWithTimes(l2F *testutils.MockL2Client, times int, refs ...eth.L2BlockRef) {
 	for _, ref := range refs {
 		l2F.ExpectL2BlockRefByNumberWithTimes(ref.Number, ref, times, nil)
 	}
 }
 
-func helperSdkClientQueryBlockRangeBabylonFinalized(t *testing.T, sdkClient *mocks.MockISdkClient, times int, refs ...eth.L2BlockRef) {
+func mockQueryBlockRangeBabylonFinalizedWithTimes(sdkClient *mocks.MockISdkClient, times int, refs ...eth.L2BlockRef) {
 	queryBlocks := make([]*cwclient.L2Block, len(refs))
 	for i, ref := range refs {
 		queryBlocks[i] = &cwclient.L2Block{

--- a/op-node/rollup/finality/finalizer_test.go
+++ b/op-node/rollup/finality/finalizer_test.go
@@ -85,7 +85,6 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		L1Origin:       refA.ID(),
 		SequenceNumber: 0,
 	}
-
 	cfg := &rollup.Config{
 		Genesis: rollup.Genesis{
 			L1:     refA.ID(),
@@ -101,7 +100,6 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		BitcoinRpc:      "https://rpc.this-is-a-mock.com/btc",
 	}
 	cfg.BabylonConfig = babylonCfg
-
 	refA1 := eth.L2BlockRef{
 		Hash:           testutils.RandomHash(rng),
 		Number:         refA0.Number + 1,
@@ -203,46 +201,16 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		l2F := &testutils.MockL2Client{}
 		defer l2F.AssertExpectations(t)
-		l2F.ExpectL2BlockRefByNumber(refA1.Number, refA1, nil)
-		l2F.ExpectL2BlockRefByNumber(refB0.Number, refB0, nil)
-		l2F.ExpectL2BlockRefByNumber(refB1.Number, refB1, nil)
-		l2F.ExpectL2BlockRefByNumber(refC0.Number, refC0, nil)
-		l2F.ExpectL2BlockRefByNumber(refC1.Number, refC1, nil)
+		helperL2BlockRefByNumberWithTimes(t, l2F, 1, refA1, refB0, refB1, refC0, refC1)
+
+		emitter := &testutils.MockEmitter{}
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{BabylonConfig: babylonCfg}, l1F, l2F, emitter)
 
 		ctl := gomock.NewController(t)
 		defer ctl.Finish()
 		sdkClient := mocks.NewMockISdkClient(ctl)
-		queryBlocks := make([]*cwclient.L2Block, refC1.Number)
-		queryBlocks[0] = &cwclient.L2Block{
-			BlockHeight:    refA1.Number,
-			BlockHash:      refA1.Hash.String(),
-			BlockTimestamp: refA1.Time,
-		}
-		queryBlocks[1] = &cwclient.L2Block{
-			BlockHeight:    refB0.Number,
-			BlockHash:      refB0.Hash.String(),
-			BlockTimestamp: refB0.Time,
-		}
-		queryBlocks[2] = &cwclient.L2Block{
-			BlockHeight:    refB1.Number,
-			BlockHash:      refB1.Hash.String(),
-			BlockTimestamp: refB1.Time,
-		}
-		queryBlocks[3] = &cwclient.L2Block{
-			BlockHeight:    refC0.Number,
-			BlockHash:      refC0.Hash.String(),
-			BlockTimestamp: refC0.Time,
-		}
-		queryBlocks[4] = &cwclient.L2Block{
-			BlockHeight:    refC1.Number,
-			BlockHash:      refC1.Hash.String(),
-			BlockTimestamp: refC1.Time,
-		}
-		sdkClient.EXPECT().QueryBlockRangeBabylonFinalized(queryBlocks).Return(&refC1.Number, nil)
-
-		emitter := &testutils.MockEmitter{}
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{BabylonConfig: babylonCfg}, l1F, l2F, emitter)
 		fi.babylonFinalityClient = sdkClient
+		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 1, refA1, refB0, refB1, refC0, refC1)
 
 		// now say C1 was included in D and became the new safe head
 		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1, DerivedFrom: refD})
@@ -277,51 +245,15 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		l2F := &testutils.MockL2Client{}
 		defer l2F.AssertExpectations(t)
-		l2F.ExpectL2BlockRefByNumber(refA1.Number, refA1, nil)
-		l2F.ExpectL2BlockRefByNumber(refB0.Number, refB0, nil)
-		l2F.ExpectL2BlockRefByNumber(refB1.Number, refB1, nil)
-		l2F.ExpectL2BlockRefByNumber(refC0.Number, refC0, nil)
-		l2F.ExpectL2BlockRefByNumber(refC1.Number, refC1, nil)
-		l2F.ExpectL2BlockRefByNumber(refA1.Number, refA1, nil)
-		l2F.ExpectL2BlockRefByNumber(refB0.Number, refB0, nil)
-		l2F.ExpectL2BlockRefByNumber(refB1.Number, refB1, nil)
-		l2F.ExpectL2BlockRefByNumber(refC0.Number, refC0, nil)
-		l2F.ExpectL2BlockRefByNumber(refC1.Number, refC1, nil)
-
-		ctl := gomock.NewController(t)
-		defer ctl.Finish()
-		sdkClient := mocks.NewMockISdkClient(ctl)
-		queryBlocks := make([]*cwclient.L2Block, refC1.Number)
-		queryBlocks[0] = &cwclient.L2Block{
-			BlockHeight:    refA1.Number,
-			BlockHash:      refA1.Hash.String(),
-			BlockTimestamp: refA1.Time,
-		}
-		queryBlocks[1] = &cwclient.L2Block{
-			BlockHeight:    refB0.Number,
-			BlockHash:      refB0.Hash.String(),
-			BlockTimestamp: refB0.Time,
-		}
-		queryBlocks[2] = &cwclient.L2Block{
-			BlockHeight:    refB1.Number,
-			BlockHash:      refB1.Hash.String(),
-			BlockTimestamp: refB1.Time,
-		}
-		queryBlocks[3] = &cwclient.L2Block{
-			BlockHeight:    refC0.Number,
-			BlockHash:      refC0.Hash.String(),
-			BlockTimestamp: refC0.Time,
-		}
-		queryBlocks[4] = &cwclient.L2Block{
-			BlockHeight:    refC1.Number,
-			BlockHash:      refC1.Hash.String(),
-			BlockTimestamp: refC1.Time,
-		}
-		sdkClient.EXPECT().QueryBlockRangeBabylonFinalized(queryBlocks).Return(&refC1.Number, nil).AnyTimes()
+		helperL2BlockRefByNumberWithTimes(t, l2F, 2, refA1, refB0, refB1, refC0, refC1)
 
 		emitter := &testutils.MockEmitter{}
 		fi := NewFinalizer(context.Background(), logger, &rollup.Config{BabylonConfig: babylonCfg}, l1F, l2F, emitter)
+		ctl := gomock.NewController(t)
+		defer ctl.Finish()
+		sdkClient := mocks.NewMockISdkClient(ctl)
 		fi.babylonFinalityClient = sdkClient
+		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 2, refA1, refB0, refB1, refC0, refC1)
 
 		// now say C1 was included in D and became the new safe head
 		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1, DerivedFrom: refD})
@@ -362,12 +294,11 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		l2F := &testutils.MockL2Client{}
 		defer l2F.AssertExpectations(t)
 
+		emitter := &testutils.MockEmitter{}
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{BabylonConfig: babylonCfg}, l1F, l2F, emitter)
 		ctl := gomock.NewController(t)
 		defer ctl.Finish()
 		sdkClient := mocks.NewMockISdkClient(ctl)
-
-		emitter := &testutils.MockEmitter{}
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{BabylonConfig: babylonCfg}, l1F, l2F, emitter)
 		fi.babylonFinalityClient = sdkClient
 
 		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1, DerivedFrom: refD})
@@ -383,43 +314,12 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		fi.OnEvent(FinalizeL1Event{FinalizedL1: refD})
 		emitter.AssertExpectations(t)
 
-		queryBlocks := make([]*cwclient.L2Block, refC1.Number)
-		queryBlocks[0] = &cwclient.L2Block{
-			BlockHeight:    refA1.Number,
-			BlockHash:      refA1.Hash.String(),
-			BlockTimestamp: refA1.Time,
-		}
-		queryBlocks[1] = &cwclient.L2Block{
-			BlockHeight:    refB0.Number,
-			BlockHash:      refB0.Hash.String(),
-			BlockTimestamp: refB0.Time,
-		}
-		queryBlocks[2] = &cwclient.L2Block{
-			BlockHeight:    refB1.Number,
-			BlockHash:      refB1.Hash.String(),
-			BlockTimestamp: refB1.Time,
-		}
-		queryBlocks[3] = &cwclient.L2Block{
-			BlockHeight:    refC0.Number,
-			BlockHash:      refC0.Hash.String(),
-			BlockTimestamp: refC0.Time,
-		}
-		queryBlocks[4] = &cwclient.L2Block{
-			BlockHeight:    refC1.Number,
-			BlockHash:      refC1.Hash.String(),
-			BlockTimestamp: refC1.Time,
-		}
-		sdkClient.EXPECT().QueryBlockRangeBabylonFinalized(queryBlocks).Return(&refC1.Number, nil).AnyTimes()
-
 		// C1 was included in D, and should be finalized now
 		emitter.ExpectOnce(engine.PromoteFinalizedEvent{Ref: refC1})
 		l1F.ExpectL1BlockRefByNumber(refD.Number, refD, nil)
 		l1F.ExpectL1BlockRefByNumber(refD.Number, refD, nil)
-		l2F.ExpectL2BlockRefByNumber(refA1.Number, refA1, nil)
-		l2F.ExpectL2BlockRefByNumber(refB0.Number, refB0, nil)
-		l2F.ExpectL2BlockRefByNumber(refB1.Number, refB1, nil)
-		l2F.ExpectL2BlockRefByNumber(refC0.Number, refC0, nil)
-		l2F.ExpectL2BlockRefByNumber(refC1.Number, refC1, nil)
+		helperL2BlockRefByNumberWithTimes(t, l2F, 2, refA1, refB0, refB1, refC0, refC1)
+		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 2, refA1, refB0, refB1, refC0, refC1)
 		fi.OnEvent(TryFinalizeEvent{})
 		emitter.AssertExpectations(t)
 		l1F.AssertExpectations(t)
@@ -429,24 +329,12 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		fi.OnEvent(FinalizeL1Event{FinalizedL1: refE})
 		emitter.AssertExpectations(t)
 
-		queryBlocksTwo := make([]*cwclient.L2Block, 1)
-		queryBlocksTwo[0] = &cwclient.L2Block{
-			BlockHeight:    refD0.Number,
-			BlockHash:      refD0.Hash.String(),
-			BlockTimestamp: refD0.Time,
-		}
-		sdkClient.EXPECT().QueryBlockRangeBabylonFinalized(queryBlocksTwo).Return(&refD0.Number, nil).AnyTimes()
-
 		// D0 was included in E, and should be finalized now
 		emitter.ExpectOnce(engine.PromoteFinalizedEvent{Ref: refD0})
 		l1F.ExpectL1BlockRefByNumber(refE.Number, refE, nil)
 		l1F.ExpectL1BlockRefByNumber(refE.Number, refE, nil)
-		l2F.ExpectL2BlockRefByNumber(refA1.Number, refA1, nil)
-		l2F.ExpectL2BlockRefByNumber(refB0.Number, refB0, nil)
-		l2F.ExpectL2BlockRefByNumber(refB1.Number, refB1, nil)
-		l2F.ExpectL2BlockRefByNumber(refC0.Number, refC0, nil)
-		l2F.ExpectL2BlockRefByNumber(refC1.Number, refC1, nil)
-		l2F.ExpectL2BlockRefByNumber(refD0.Number, refD0, nil)
+		helperL2BlockRefByNumberWithTimes(t, l2F, 1, refD0)
+		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 1, refD0)
 		fi.OnEvent(TryFinalizeEvent{})
 		emitter.AssertExpectations(t)
 		l1F.AssertExpectations(t)
@@ -481,43 +369,12 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		fi.OnEvent(FinalizeL1Event{FinalizedL1: refH})
 		emitter.AssertExpectations(t)
 
-		queryBlocksThree := make([]*cwclient.L2Block, 5)
-		queryBlocksThree[0] = &cwclient.L2Block{
-			BlockHeight:    refD1.Number,
-			BlockHash:      refD1.Hash.String(),
-			BlockTimestamp: refD1.Time,
-		}
-		queryBlocksThree[1] = &cwclient.L2Block{
-			BlockHeight:    refE0.Number,
-			BlockHash:      refE0.Hash.String(),
-			BlockTimestamp: refE0.Time,
-		}
-		queryBlocksThree[2] = &cwclient.L2Block{
-			BlockHeight:    refE1.Number,
-			BlockHash:      refE1.Hash.String(),
-			BlockTimestamp: refE1.Time,
-		}
-		queryBlocksThree[3] = &cwclient.L2Block{
-			BlockHeight:    refF0.Number,
-			BlockHash:      refF0.Hash.String(),
-			BlockTimestamp: refF0.Time,
-		}
-		queryBlocksThree[4] = &cwclient.L2Block{
-			BlockHeight:    refF1.Number,
-			BlockHash:      refF1.Hash.String(),
-			BlockTimestamp: refF1.Time,
-		}
-		sdkClient.EXPECT().QueryBlockRangeBabylonFinalized(queryBlocksThree).Return(&refF1.Number, nil).AnyTimes()
-
 		// F1 should be finalized now, since it was included in H
 		emitter.ExpectOnce(engine.PromoteFinalizedEvent{Ref: refF1})
 		l1F.ExpectL1BlockRefByNumber(refH.Number, refH, nil)
 		l1F.ExpectL1BlockRefByNumber(refH.Number, refH, nil)
-		l2F.ExpectL2BlockRefByNumber(refD1.Number, refD1, nil)
-		l2F.ExpectL2BlockRefByNumber(refE0.Number, refE0, nil)
-		l2F.ExpectL2BlockRefByNumber(refE1.Number, refE1, nil)
-		l2F.ExpectL2BlockRefByNumber(refF0.Number, refF0, nil)
-		l2F.ExpectL2BlockRefByNumber(refF1.Number, refF1, nil)
+		helperL2BlockRefByNumberWithTimes(t, l2F, 1, refD1, refE0, refE1, refF0, refF1)
+		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 1, refD1, refE0, refE1, refF0, refF1)
 		fi.OnEvent(TryFinalizeEvent{})
 		emitter.AssertExpectations(t)
 		l1F.AssertExpectations(t)
@@ -534,34 +391,15 @@ func TestEngineQueue_Finalize(t *testing.T) {
 
 		l2F := &testutils.MockL2Client{}
 		defer l2F.AssertExpectations(t)
-		l2F.ExpectL2BlockRefByNumber(refA1.Number, refA1, nil)
-		l2F.ExpectL2BlockRefByNumber(refB0.Number, refB0, nil)
-		l2F.ExpectL2BlockRefByNumber(refB1.Number, refB1, nil)
-
-		ctl := gomock.NewController(t)
-		defer ctl.Finish()
-		sdkClient := mocks.NewMockISdkClient(ctl)
-		queryBlocks := make([]*cwclient.L2Block, refB1.Number)
-		queryBlocks[0] = &cwclient.L2Block{
-			BlockHeight:    refA1.Number,
-			BlockHash:      refA1.Hash.String(),
-			BlockTimestamp: refA1.Time,
-		}
-		queryBlocks[1] = &cwclient.L2Block{
-			BlockHeight:    refB0.Number,
-			BlockHash:      refB0.Hash.String(),
-			BlockTimestamp: refB0.Time,
-		}
-		queryBlocks[2] = &cwclient.L2Block{
-			BlockHeight:    refB1.Number,
-			BlockHash:      refB1.Hash.String(),
-			BlockTimestamp: refB1.Time,
-		}
-		sdkClient.EXPECT().QueryBlockRangeBabylonFinalized(queryBlocks).Return(&refB1.Number, nil)
+		helperL2BlockRefByNumberWithTimes(t, l2F, 1, refA1, refB0, refB1)
 
 		emitter := &testutils.MockEmitter{}
 		fi := NewFinalizer(context.Background(), logger, &rollup.Config{BabylonConfig: babylonCfg}, l1F, l2F, emitter)
+		ctl := gomock.NewController(t)
+		defer ctl.Finish()
+		sdkClient := mocks.NewMockISdkClient(ctl)
 		fi.babylonFinalityClient = sdkClient
+		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 1, refA1, refB0, refB1)
 
 		// now say B1 was included in C and became the new safe head
 		fi.OnEvent(engine.SafeDerivedEvent{Safe: refB1, DerivedFrom: refC})
@@ -599,12 +437,11 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		l2F := &testutils.MockL2Client{}
 		defer l2F.AssertExpectations(t)
 
+		emitter := &testutils.MockEmitter{}
+		fi := NewFinalizer(context.Background(), logger, &rollup.Config{BabylonConfig: babylonCfg}, l1F, l2F, emitter)
 		ctl := gomock.NewController(t)
 		defer ctl.Finish()
 		sdkClient := mocks.NewMockISdkClient(ctl)
-
-		emitter := &testutils.MockEmitter{}
-		fi := NewFinalizer(context.Background(), logger, &rollup.Config{BabylonConfig: babylonCfg}, l1F, l2F, emitter)
 		fi.babylonFinalityClient = sdkClient
 
 		// now say B1 was included in C and became the new safe head
@@ -638,48 +475,9 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC0Alt, DerivedFrom: refDAlt})
 		fi.OnEvent(engine.SafeDerivedEvent{Safe: refC1Alt, DerivedFrom: refDAlt})
 
-		l2F.ExpectL2BlockRefByNumber(refA1.Number, refA1, nil)
-		l2F.ExpectL2BlockRefByNumber(refB0.Number, refB0, nil)
-		l2F.ExpectL2BlockRefByNumber(refB1.Number, refB1, nil)
-		l2F.ExpectL2BlockRefByNumber(refC0Alt.Number, refC0Alt, nil)
-		l2F.ExpectL2BlockRefByNumber(refC1Alt.Number, refC1Alt, nil)
-
-		l2F.ExpectL2BlockRefByNumber(refA1.Number, refA1, nil)
-		l2F.ExpectL2BlockRefByNumber(refB0.Number, refB0, nil)
-		l2F.ExpectL2BlockRefByNumber(refB1.Number, refB1, nil)
-		l2F.ExpectL2BlockRefByNumber(refC0Alt.Number, refC0Alt, nil)
-		l2F.ExpectL2BlockRefByNumber(refC1Alt.Number, refC1Alt, nil)
-
-		queryBlocks := make([]*cwclient.L2Block, refB1.Number)
-		queryBlocks[0] = &cwclient.L2Block{
-			BlockHeight:    refA1.Number,
-			BlockHash:      refA1.Hash.String(),
-			BlockTimestamp: refA1.Time,
-		}
-		queryBlocks[1] = &cwclient.L2Block{
-			BlockHeight:    refB0.Number,
-			BlockHash:      refB0.Hash.String(),
-			BlockTimestamp: refB0.Time,
-		}
-		queryBlocks[2] = &cwclient.L2Block{
-			BlockHeight:    refB1.Number,
-			BlockHash:      refB1.Hash.String(),
-			BlockTimestamp: refB1.Time,
-		}
-		sdkClient.EXPECT().QueryBlockRangeBabylonFinalized(queryBlocks).Return(&refB1.Number, nil).AnyTimes()
-
-		queryBlocksTwo := make([]*cwclient.L2Block, 2)
-		queryBlocksTwo[0] = &cwclient.L2Block{
-			BlockHeight:    refC0Alt.Number,
-			BlockHash:      refC0Alt.Hash.String(),
-			BlockTimestamp: refC0Alt.Time,
-		}
-		queryBlocksTwo[1] = &cwclient.L2Block{
-			BlockHeight:    refC1Alt.Number,
-			BlockHash:      refC1Alt.Hash.String(),
-			BlockTimestamp: refC1Alt.Time,
-		}
-		sdkClient.EXPECT().QueryBlockRangeBabylonFinalized(queryBlocksTwo).Return(&refC1Alt.Number, nil).AnyTimes()
+		helperL2BlockRefByNumberWithTimes(t, l2F, 2, refA1, refB0, refB1, refC0Alt, refC1Alt)
+		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 2, refA1, refB0, refB1)
+		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 2, refC0Alt, refC1Alt)
 
 		// We get an early finality signal for F, of the chain that did not include refC0Alt and refC1Alt,
 		// as L1 block F does not build on DAlt.
@@ -721,33 +519,8 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		// and don't expect a finality attempt.
 		emitter.AssertExpectations(t)
 
-		l2F.ExpectL2BlockRefByNumber(refA1.Number, refA1, nil)
-		l2F.ExpectL2BlockRefByNumber(refB0.Number, refB0, nil)
-		l2F.ExpectL2BlockRefByNumber(refB1.Number, refB1, nil)
-		l2F.ExpectL2BlockRefByNumber(refC0.Number, refC0, nil)
-
-		queryBlocksThree := make([]*cwclient.L2Block, refC0.Number)
-		queryBlocksThree[0] = &cwclient.L2Block{
-			BlockHeight:    refA1.Number,
-			BlockHash:      refA1.Hash.String(),
-			BlockTimestamp: refA1.Time,
-		}
-		queryBlocksThree[1] = &cwclient.L2Block{
-			BlockHeight:    refB0.Number,
-			BlockHash:      refB0.Hash.String(),
-			BlockTimestamp: refB0.Time,
-		}
-		queryBlocksThree[2] = &cwclient.L2Block{
-			BlockHeight:    refB1.Number,
-			BlockHash:      refB1.Hash.String(),
-			BlockTimestamp: refB1.Time,
-		}
-		queryBlocksThree[3] = &cwclient.L2Block{
-			BlockHeight:    refC0.Number,
-			BlockHash:      refC0.Hash.String(),
-			BlockTimestamp: refC0.Time,
-		}
-		sdkClient.EXPECT().QueryBlockRangeBabylonFinalized(queryBlocksThree).Return(&refC0.Number, nil)
+		helperL2BlockRefByNumberWithTimes(t, l2F, 1, refA1, refB0, refB1, refC0)
+		helperSdkClientQueryBlockRangeBabylonFinalized(t, sdkClient, 1, refA1, refB0, refB1, refC0)
 
 		// if we reset the attempt, then we can finalize however.
 		fi.triedFinalizeAt = 0
@@ -758,4 +531,22 @@ func TestEngineQueue_Finalize(t *testing.T) {
 		fi.OnEvent(TryFinalizeEvent{})
 		emitter.AssertExpectations(t)
 	})
+}
+
+func helperL2BlockRefByNumberWithTimes(t *testing.T, l2F *testutils.MockL2Client, times int, refs ...eth.L2BlockRef) {
+	for _, ref := range refs {
+		l2F.ExpectL2BlockRefByNumberWithTimes(ref.Number, ref, times, nil)
+	}
+}
+
+func helperSdkClientQueryBlockRangeBabylonFinalized(t *testing.T, sdkClient *mocks.MockISdkClient, times int, refs ...eth.L2BlockRef) {
+	queryBlocks := make([]*cwclient.L2Block, len(refs))
+	for i, ref := range refs {
+		queryBlocks[i] = &cwclient.L2Block{
+			BlockHeight:    ref.Number,
+			BlockHash:      ref.Hash.String(),
+			BlockTimestamp: ref.Time,
+		}
+	}
+	sdkClient.EXPECT().QueryBlockRangeBabylonFinalized(queryBlocks).Return(&refs[len(refs)-1].Number, nil).Times(times)
 }

--- a/op-service/testutils/mock_l2.go
+++ b/op-service/testutils/mock_l2.go
@@ -29,6 +29,10 @@ func (m *MockL2Client) ExpectL2BlockRefByNumber(num uint64, ref eth.L2BlockRef, 
 	m.Mock.On("L2BlockRefByNumber", num).Once().Return(ref, &err)
 }
 
+func (m *MockL2Client) ExpectL2BlockRefByNumberWithTimes(num uint64, ref eth.L2BlockRef, times int, err error) {
+	m.Mock.On("L2BlockRefByNumber", num).Times(times).Return(ref, &err)
+}
+
 func (c *MockL2Client) L2BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L2BlockRef, error) {
 	out := c.Mock.Called(hash)
 	return out.Get(0).(eth.L2BlockRef), out.Error(1)


### PR DESCRIPTION
## Summary

This PR completed the first task in https://github.com/babylonchain/optimism/issues/24 to fix the failed tests in the `finalizer_test.go`.


We updated `finalizer.go` to check the finality on each L2 block in this PR https://github.com/babylonchain/optimism/pull/23#issue-2404494291, which

* added a `l2Fetcher` to fetch each L2 block
   
	```Go
	type FinalizerL2Interface interface {
		L2BlockRefByNumber(context.Context, uint64) (eth.L2BlockRef, error)
	}
	```
* updated the SDK query function to check a range of L2 blocks

	```Go
	type BabylonFinalityClient interface {
		QueryBlockRangeBabylonFinalized(queryBlocks []*cwclient.L2Block) (*uint64, error)
	}
	```

So we added two helper functions in the `finalizer_test.go`.

```Go
func mockL2BlockRefByNumberWithTimes(l2F *testutils.MockL2Client, times int, refs ...eth.L2BlockRef)
func mockQueryBlockRangeBabylonFinalizedWithTimes(sdkClient *mocks.MockISdkClient, times int, refs ...eth.L2BlockRef)
```

Also, we added a function in the `mock_l2.go`  to support the mock times.

```Go
func (m *MockL2Client) ExpectL2BlockRefByNumberWithTimes(num uint64, ref eth.L2BlockRef, times int, err error)
```


## Test Plan

```
make lint-go

cd op-node
make test
```

Also, connect with FP e2e tests locally and make sure all test cases are passed.
